### PR TITLE
Fix jar name in instruction sample of swagger-java-dropwizard-sample-app

### DIFF
--- a/java/java-dropwizard/README.md
+++ b/java/java-dropwizard/README.md
@@ -3,7 +3,7 @@ To run the sample:
 ```
 mvn package
 
-java -jar target/swagger-java-dropwizard-sample-app-1.0.0.jar server conf/swagger-sample.yml 
+java -jar target/swagger-java-dropwizard-sample-app-2.0.0.jar server conf/swagger-sample.yml
 
 ```
 


### PR DESCRIPTION
Commit 6fe9f6d changed version of the package from 1.0.0 to 2.0.0 but
the instruction text was not updated.