### PR TITLE
Document objectMapper configuration

### DIFF
--- a/java/java-dropwizard/src/main/java/io/swagger/sample/SwaggerSampleApplication.java
+++ b/java/java-dropwizard/src/main/java/io/swagger/sample/SwaggerSampleApplication.java
@@ -28,6 +28,8 @@ public class SwaggerSampleApplication extends Application <SwaggerSampleConfigur
   public void run(SwaggerSampleConfiguration configuration, Environment environment) {
     environment.jersey().register(new ApiListingResource());
     environment.jersey().register(new PetResource());
+    //the next line will become obsolet with the next release of swagger-jaxrs
+    //see https://github.com/swagger-api/swagger-core/pull/2106
     environment.getObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
     BeanConfig config = new BeanConfig();


### PR DESCRIPTION
Explain that JsonInclude.Non_Null is only needed until the next release of swagger-jaxrs
Once it is out, we can completly remove the line