### PR TITLE
Add guards around structures to prevent racing.

### DIFF
--- a/java/java-jersey-jaxrs/src/main/java/io/swagger/sample/data/PetData.java
+++ b/java/java-jersey-jaxrs/src/main/java/io/swagger/sample/data/PetData.java
@@ -23,8 +23,9 @@ import io.swagger.sample.model.Tag;
 import java.util.*;
 
 public class PetData {
-  static List<Pet> pets = new ArrayList<Pet>();
-  static List<Category> categories = new ArrayList<Category>();
+
+  static List<Pet> pets = Collections.synchronizedList(new ArrayList<Pet>());
+  static List<Category> categories = Collections.synchronizedList(new ArrayList<Category>());
 
   static {
     categories.add(createCategory(1, "Dogs"));
@@ -68,11 +69,13 @@ public class PetData {
 
   public boolean deletePet(long petId) {
     if(pets.size() > 0) {
-      for (int i = pets.size() - 1; i >= 0; i--) {
-        Pet pet = pets.get(i);
-        if(pet.getId() == petId) {
-          pets.remove(i);
-          return true;
+      synchronized (pets) {
+        for (int i = pets.size() - 1; i >= 0; i--) {
+          Pet pet = pets.get(i);
+          if(pet.getId() == petId) {
+            pets.remove(i);
+            return true;
+          }
         }
       }
     }
@@ -85,10 +88,12 @@ public class PetData {
       return result;
     }
     String[] statuses = status.split(",");
-    for (Pet pet : pets) {
-      for (String s : statuses) {
-        if (s.equals(pet.getStatus())) {
-          result.add(pet);
+    synchronized (pets) {
+      for (Pet pet : pets) {
+        for (String s : statuses) {
+          if (s.equals(pet.getStatus())) {
+            result.add(pet);
+          }
         }
       }
     }
@@ -102,12 +107,14 @@ public class PetData {
       return result;
     }    
     String[] tagList = tags.split(",");
-    for (Pet pet : pets) {
-      if (null != pet.getTags()) {
-        for (Tag tag : pet.getTags()) {
-          for (String tagListString : tagList) {
-            if (tagListString.equals(tag.getName()))
-              result.add(pet);
+    synchronized (pets) {
+      for (Pet pet : pets) {
+        if (null != pet.getTags()) {
+          for (Tag tag : pet.getTags()) {
+            for (String tagListString : tagList) {
+              if (tagListString.equals(tag.getName()))
+                result.add(pet);
+            }
           }
         }
       }
@@ -116,37 +123,41 @@ public class PetData {
   }
 
   public Pet addPet(Pet pet) {
-    if(pet.getId() == 0) {
-      long maxId = 0;
-      for (int i = pets.size() - 1; i >= 0; i--) {
-        if(pets.get(i).getId() > maxId) {
-          maxId = pets.get(i).getId();
+    synchronized (pets) {
+      if(pet.getId() == 0) {
+        long maxId = 0;
+        for (int i = pets.size() - 1; i >= 0; i--) {
+          if(pets.get(i).getId() > maxId) {
+            maxId = pets.get(i).getId();
+          }
+        }
+        pet.setId(maxId + 1);
+      }
+      if (pets.size() > 0) {
+        for (int i = pets.size() - 1; i >= 0; i--) {
+          if (pets.get(i).getId() == pet.getId()) {
+            pets.remove(i);
+          }
         }
       }
-      pet.setId(maxId + 1);
+      pets.add(pet);
     }
-    if (pets.size() > 0) {
-      for (int i = pets.size() - 1; i >= 0; i--) {
-        if (pets.get(i).getId() == pet.getId()) {
-          pets.remove(i);
-        }
-      }
-    }
-    pets.add(pet);
     return pet;
   }
 
   public Map<String, Integer> getInventoryByStatus() {
     Map<String, Integer> output = new HashMap<String, Integer>();
-    for(Pet pet : pets) {
-      String status = pet.getStatus();
-      if(status != null && !"".equals(status)) {
-        Integer count = output.get(status);
-        if(count == null)
-          count = new Integer(1);
-        else
-          count = count.intValue() + 1;
-        output.put(status, count);
+    synchronized (pets) {
+      for(Pet pet : pets) {
+        String status = pet.getStatus();
+        if(status != null && !"".equals(status)) {
+          Integer count = output.get(status);
+          if(count == null)
+            count = new Integer(1);
+          else
+            count = count.intValue() + 1;
+          output.put(status, count);
+        }
       }
     }
     return output;

--- a/java/java-jersey-jaxrs/src/main/java/io/swagger/sample/data/StoreData.java
+++ b/java/java-jersey-jaxrs/src/main/java/io/swagger/sample/data/StoreData.java
@@ -18,12 +18,10 @@ package io.swagger.sample.data;
 
 import io.swagger.sample.model.Order;
 
-import java.util.Date;
-import java.util.List;
-import java.util.ArrayList;
+import java.util.*;
 
 public class StoreData {
-  static List<Order> orders = new ArrayList<Order>();
+  static List<Order> orders = Collections.synchronizedList(new ArrayList<Order>());
 
   static {
     orders.add(createOrder(1, 1, 2, new Date(), "placed"));
@@ -39,32 +37,38 @@ public class StoreData {
   }
 
   public Order findOrderById(long orderId) {
-    for (Order order : orders) {
-      if (order.getId() == orderId) {
-        return order;
+    synchronized (orders) {
+      for (Order order : orders) {
+        if (order.getId() == orderId) {
+          return order;
+        }
       }
     }
     return null;
   }
 
   public Order placeOrder(Order order) {
-    if (orders.size() > 0) {
-      for (int i = orders.size() - 1; i >= 0; i--) {
-        if (orders.get(i).getId() == order.getId()) {
-          orders.remove(i);
-        }
+    synchronized (orders) {
+      if (orders.size() > 0) {
+          for (int i = orders.size() - 1; i >= 0; i--) {
+            if (orders.get(i).getId() == order.getId()) {
+              orders.remove(i);
+            }
+          }
+        orders.add(order);
       }
+      return order;
     }
-    orders.add(order);
-    return order;
   }
 
   public boolean deleteOrder(long orderId) {
     if (orders.size() > 0) {
-      for (int i = orders.size() - 1; i >= 0; i--) {
-        if (orders.get(i).getId() == orderId) {
-          orders.remove(i);
-          return true;
+      synchronized (orders) {
+        for (int i = orders.size() - 1; i >= 0; i--) {
+          if (orders.get(i).getId() == orderId) {
+            orders.remove(i);
+            return true;
+          }
         }
       }
     }

--- a/java/java-jersey-jaxrs/src/main/java/io/swagger/sample/data/UserData.java
+++ b/java/java-jersey-jaxrs/src/main/java/io/swagger/sample/data/UserData.java
@@ -18,11 +18,10 @@ package io.swagger.sample.data;
 
 import io.swagger.sample.model.User;
 
-import java.util.List;
-import java.util.ArrayList;
+import java.util.*;
 
 public class UserData {
-  static List<User> users = new ArrayList<User>();
+  static List<User> users = Collections.synchronizedList( new ArrayList<User>() );
 
   static {
     users.add(createUser(1, "user1", "first name 1", "last name 1",
@@ -51,9 +50,11 @@ public class UserData {
   }
 
   public User findUserByName(String username) {
-    for (User user : users) {
-      if (user.getUsername().equals(username)) {
-        return user;
+    synchronized (users) {
+      for (User user : users) {
+        if (user.getUsername().equals(username)) {
+          return user;
+        }
       }
     }
     return null;
@@ -62,22 +63,27 @@ public class UserData {
   public void addUser(User user) {
     if(user.getUsername() == null)
       return;
-    if (users.size() > 0) {
-      for (int i = users.size() - 1; i >= 0; i--) {
-        if (users.get(i).getUsername().equals(user.getUsername())) {
-          users.remove(i);
+
+    synchronized (users) {
+      if (users.size() > 0) {
+        for (int i = users.size() - 1; i >= 0; i--) {
+          if (users.get(i).getUsername().equals(user.getUsername())) {
+            users.remove(i);
+          }
         }
       }
+      users.add(user);
     }
-    users.add(user);
   }
 
   public boolean removeUser(String username) {
     if (users.size() > 0) {
-      for (int i = users.size() - 1; i >= 0; i--) {
-        if (users.get(i).getUsername().equals(username)) {
-          users.remove(i);
-          return true;
+      synchronized (users) {
+        for (int i = users.size() - 1; i >= 0; i--) {
+          if (users.get(i).getUsername().equals(username)) {
+            users.remove(i);
+            return true;
+          }
         }
       }
     }


### PR DESCRIPTION
@wing328 From what I can tell, there are races around the data structures here when hit concurrently.

Please review and make sure my use of `Collections.synchronizedList` and `synchronized` are correct. I have not written anything in Java for some time.

I have these changes running locally with `go test` on a loop and beefed up the concurrency significantly in the go tests. Running 30 minutes with no failures now. This should resolve swagger-codegen #5102.