### PR TITLE
fixed duplicate artifactId

### DIFF
--- a/java/java-jersey-jaxrs-multi-use-basepath/pom.xml
+++ b/java/java-jersey-jaxrs-multi-use-basepath/pom.xml
@@ -7,9 +7,9 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.swagger</groupId>
-  <artifactId>swagger-java-jersey-multi-sample-app</artifactId>
+  <artifactId>swagger-java-jersey-multi-use-basepath-sample-app</artifactId>
   <packaging>war</packaging>
-  <name>swagger-java-jersey-jaxrs-multi-app</name>
+  <name>swagger-java-jersey-jaxrs-multi-use-basepath-app</name>
   <version>1.0.0</version>
   <build>
     <sourceDirectory>src/main/java</sourceDirectory>


### PR DESCRIPTION
Build failed because swagger-java-jersey-multi-sample-app artifactId is used by two projects. Renamed one of that.

[ERROR] Project 'io.swagger:swagger-java-jersey-multi-sample-app:1.0.0' is duplicated in the reactor @
[ERROR] Project 'io.swagger:swagger-java-jersey-multi-sample-app:1.0.0' is duplicated in the reactor -> [Help 1]
[ERROR]
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DuplicateProjectException