### PR TITLE
Fixing jetty version in pom inflector-jetty-webxml

### DIFF
--- a/java/inflector-jetty-webxml/pom.xml
+++ b/java/inflector-jetty-webxml/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.swagger</groupId>
     <artifactId>jetty-webxml-sample</artifactId>
-    <packaging>jar</packaging>
+    <packaging>war</packaging>
     <name>jetty-webxml-sample</name>
     <version>1.0.0-SNAPSHOT</version>
     <prerequisites>
@@ -118,7 +118,7 @@
     </dependencies>
     <properties>
         <maven-plugin-version>1.0.0</maven-plugin-version>
-        <jetty-version>9.2.9.v20150224</jetty-version>
+        <jetty-version>9.4.9.v20180320</jetty-version>
         <logback-version>1.0.1</logback-version>
         <inflector-version>2.0.0-SNAPSHOT</inflector-version>
         <junit-version>4.8.2</junit-version>


### PR DESCRIPTION
Fixing jetty version in pom inflector-jetty-webxml