### PR TITLE
Update in defining "url" inside SwaggerUIBundle

### DIFF
--- a/java/swagger-petstore/src/main/webapp/index.html
+++ b/java/swagger-petstore/src/main/webapp/index.html
@@ -74,7 +74,7 @@
     // Build a system
     const ui = SwaggerUIBundle({
       oauth2RedirectUrl:  window.location.protocol + '//' + window.location.host + '/oauth2-redirect.html',
-      url: "/api/v3/openapi.json",
+      url: "/openapi.json",
       dom_id: '#swagger-ui',
       presets: [
         SwaggerUIBundle.presets.apis,

--- a/java/swagger-petstore/src/main/webapp/index.html
+++ b/java/swagger-petstore/src/main/webapp/index.html
@@ -72,10 +72,9 @@
 <script>
   window.onload = function() {
     // Build a system
-    apiUrl = window.location.protocol + "//" + window.location.host + "/api/v3/openapi.json";
     const ui = SwaggerUIBundle({
       oauth2RedirectUrl:  window.location.protocol + '//' + window.location.host + '/oauth2-redirect.html',
-      url: apiUrl,
+      url: "/api/v3/openapi.json",
       dom_id: '#swagger-ui',
       presets: [
         SwaggerUIBundle.presets.apis,

--- a/java/swagger-petstore/src/main/webapp/index.html
+++ b/java/swagger-petstore/src/main/webapp/index.html
@@ -74,7 +74,7 @@
     // Build a system
     const ui = SwaggerUIBundle({
       oauth2RedirectUrl:  window.location.protocol + '//' + window.location.host + '/oauth2-redirect.html',
-      url: "/openapi.json",
+      url: "/api/v3/openapi.json",
       dom_id: '#swagger-ui',
       presets: [
         SwaggerUIBundle.presets.apis,


### PR DESCRIPTION
generator 3 works just fine with swagger-io-proxy. Unforunately, petstore 3 has not. After hours of testing various redirects, acl rules, and other networking ideas, I decided to look at how the url is generated. I noticed that in generator, the url is simply the location of the .yaml spec. This was different for petstore 3.

Petstore 3 defined a variable named apiUrl and used the windows location and host and then appended it to the location of the .yaml spec. This meant that the 'url' variable defined inside SwaggerUIBundle would have "http://..." instead of just "/file/location.yaml", which is how it was coded in generator 3.

This code change is to test if generating the url variable in the same manor as code generator 3 addresses the issue and allows us to use swagger-io-proxy instead of an AWS ALB for Petstore 3.